### PR TITLE
dev to main sync

### DIFF
--- a/core/src/filter/ptree.rs
+++ b/core/src/filter/ptree.rs
@@ -390,8 +390,7 @@ impl PTree {
                 return;
             }
 
-            if !matches!(self.filter_layer, FilterLayer::PacketContinue) &&
-                predicate.req_packet() {
+            if !matches!(self.filter_layer, FilterLayer::PacketContinue) && predicate.req_packet() {
                 // To get similar behavior, users should subscribe to individual mbufs or
                 // the mbuf list, then filter within the callback.
                 // Because (for now) all packets would need to be tracked anyway, doing this

--- a/core/src/filter/ptree.rs
+++ b/core/src/filter/ptree.rs
@@ -390,6 +390,17 @@ impl PTree {
                 return;
             }
 
+            if !matches!(self.filter_layer, FilterLayer::PacketContinue) &&
+                predicate.req_packet() {
+                // To get similar behavior, users should subscribe to individual mbufs or
+                // the mbuf list, then filter within the callback.
+                // Because (for now) all packets would need to be tracked anyway, doing this
+                // is equivalent performance-wise to implementing similar functionality in the
+                // framework.
+                panic!("Cannot access per-packet fields (e.g., TCP flags, length) after packet filter.\n\
+                       Subscribe to `ZcFrame` or PacketList instead.");
+            }
+
             // Predicate is already present
 
             if node.has_descendant(predicate) {

--- a/filtergen/src/deliver_filter.rs
+++ b/filtergen/src/deliver_filter.rs
@@ -21,11 +21,12 @@ pub(crate) fn gen_deliver_filter(
     }
 
     gen_deliver_util(&mut body, statics, &ptree.root, filter_layer);
-
-    let connection_deliver = quote! {
-        #( #body )*
+    // Ensure root protocol is extracted
+    let body = match filter_layer {
+        FilterLayer::PacketDeliver => PacketDataFilter::add_root_pred(&ptree.root, &body),
+        _ => quote! { #( #body )* },
     };
-    connection_deliver
+    body
 }
 
 fn gen_deliver_util(
@@ -39,15 +40,28 @@ fn gen_deliver_util(
         match &child.pred {
             Predicate::Unary { protocol } => {
                 if child.pred.on_packet() {
-                    ConnDataFilter::add_unary_pred(
-                        code,
-                        statics,
-                        child,
-                        protocol,
-                        first_unary,
-                        filter_layer,
-                        &gen_deliver_util,
-                    );
+                    if matches!(filter_layer, FilterLayer::PacketDeliver) {
+                        PacketDataFilter::add_unary_pred(
+                            code,
+                            statics,
+                            child,
+                            node.pred.get_protocol(),
+                            protocol,
+                            first_unary,
+                            filter_layer,
+                            &gen_deliver_util,
+                        );
+                    } else {
+                        ConnDataFilter::add_unary_pred(
+                            code,
+                            statics,
+                            child,
+                            protocol,
+                            first_unary,
+                            filter_layer,
+                            &gen_deliver_util,
+                        );
+                    }
                     first_unary = false;
                 } else if child.pred.on_proto() {
                     ConnDataFilter::add_service_pred(
@@ -69,17 +83,31 @@ fn gen_deliver_util(
                 value,
             } => {
                 if child.pred.on_packet() {
-                    ConnDataFilter::add_binary_pred(
-                        code,
-                        statics,
-                        child,
-                        protocol,
-                        field,
-                        op,
-                        value,
-                        filter_layer,
-                        &gen_deliver_util,
-                    );
+                    if matches!(filter_layer, FilterLayer::PacketDeliver) {
+                        PacketDataFilter::add_binary_pred(
+                            code,
+                            statics,
+                            child,
+                            protocol,
+                            field,
+                            op,
+                            value,
+                            filter_layer,
+                            &gen_deliver_util
+                        );
+                    } else {
+                        ConnDataFilter::add_binary_pred(
+                            code,
+                            statics,
+                            child,
+                            protocol,
+                            field,
+                            op,
+                            value,
+                            filter_layer,
+                            &gen_deliver_util,
+                        );
+                    }
                 } else if child.pred.on_session() {
                     add_session_pred(
                         code,

--- a/filtergen/src/packet_filter.rs
+++ b/filtergen/src/packet_filter.rs
@@ -5,7 +5,6 @@ use quote::quote;
 use crate::utils::*;
 use retina_core::filter::ast::*;
 use retina_core::filter::ptree::{FilterLayer, PNode, PTree};
-use retina_core::protocol;
 
 pub(crate) fn gen_packet_filter(
     ptree: &PTree,
@@ -26,7 +25,6 @@ pub(crate) fn gen_packet_filter(
         &mut body,
         statics,
         &ptree.root,
-        &protocol!("frame"),
         filter_layer,
     );
 
@@ -56,7 +54,6 @@ fn gen_packet_filter_util(
     code: &mut Vec<proc_macro2::TokenStream>,
     statics: &mut Vec<proc_macro2::TokenStream>,
     node: &PNode,
-    outer_protocol: &ProtocolName,
     filter_layer: FilterLayer,
 ) {
     let mut first_unary = true;
@@ -85,7 +82,6 @@ fn gen_packet_filter_util(
                     code,
                     statics,
                     child,
-                    outer_protocol,
                     protocol,
                     field,
                     op,

--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -194,14 +194,6 @@ pub(crate) type BuildChildNodesFn = dyn Fn(
     FilterLayer,
 );
 
-pub(crate) type BuildChildNodesPktFn = dyn Fn(
-    &mut Vec<proc_macro2::TokenStream>,
-    &mut Vec<proc_macro2::TokenStream>,
-    &PNode,
-    &ProtocolName,
-    FilterLayer,
-);
-
 
 pub(crate) struct PacketDataFilter;
 
@@ -214,14 +206,14 @@ impl PacketDataFilter {
         protocol: &ProtocolName,
         first_unary: bool,
         filter_layer: FilterLayer,
-        build_child_nodes: &BuildChildNodesPktFn,
+        build_child_nodes: &BuildChildNodesFn,
     ) {
         let outer = Ident::new(outer_protocol.name(), Span::call_site());
         let ident = Ident::new(protocol.name(), Span::call_site());
         let ident_type = Ident::new(&ident.to_string().to_camel_case(), Span::call_site());
 
         let mut body: Vec<proc_macro2::TokenStream> = vec![];
-        (build_child_nodes)(&mut body, statics, node, outer_protocol, filter_layer);
+        (build_child_nodes)(&mut body, statics, node, filter_layer);
         update_body(&mut body, node, filter_layer, false);
 
         if first_unary {
@@ -244,16 +236,15 @@ impl PacketDataFilter {
         code: &mut Vec<proc_macro2::TokenStream>,
         statics: &mut Vec<proc_macro2::TokenStream>,
         node: &PNode,
-        outer_protocol: &ProtocolName,
         protocol: &ProtocolName,
         field: &FieldName,
         op: &BinOp,
         value: &Value,
         filter_layer: FilterLayer,
-        build_child_nodes: &BuildChildNodesPktFn,
+        build_child_nodes: &BuildChildNodesFn,
     ) {
         let mut body: Vec<proc_macro2::TokenStream> = vec![];
-        (build_child_nodes)(&mut body, statics, node, outer_protocol, filter_layer);
+        (build_child_nodes)(&mut body, statics, node, filter_layer);
         update_body(&mut body, node, filter_layer, false);
 
         let pred_tokenstream = binary_to_tokens(protocol, field, op, value, statics);

--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -262,6 +262,23 @@ impl PacketDataFilter {
             });
         }
     }
+
+    pub(crate) fn add_root_pred(root: &PNode, body: &Vec<proc_macro2::TokenStream>) -> proc_macro2::TokenStream {
+
+        let name = "ethernet";
+        let outer = Ident::new(name, Span::call_site());
+        let outer_type = Ident::new(&outer.to_string().to_camel_case(), Span::call_site());
+
+        if !body.is_empty() &&
+             root.children.iter().any(|n| n.pred.on_packet()) {
+            return quote! {
+                    if let Ok(#outer) = &retina_core::protocols::packet::Packet::parse_to::<retina_core::protocols::packet::#outer::#outer_type>(mbuf) {
+                        #( #body )*
+                    }
+                };
+        }
+        quote! { #( #body )* }
+    }
 }
 
 // \note Because each stage's filter may be different, we default to applying an

--- a/filtergen/src/utils.rs
+++ b/filtergen/src/utils.rs
@@ -194,6 +194,85 @@ pub(crate) type BuildChildNodesFn = dyn Fn(
     FilterLayer,
 );
 
+pub(crate) type BuildChildNodesPktFn = dyn Fn(
+    &mut Vec<proc_macro2::TokenStream>,
+    &mut Vec<proc_macro2::TokenStream>,
+    &PNode,
+    &ProtocolName,
+    FilterLayer,
+);
+
+
+pub(crate) struct PacketDataFilter;
+
+impl PacketDataFilter {
+    pub(crate) fn add_unary_pred(
+        code: &mut Vec<proc_macro2::TokenStream>,
+        statics: &mut Vec<proc_macro2::TokenStream>,
+        node: &PNode,
+        outer_protocol: &ProtocolName,
+        protocol: &ProtocolName,
+        first_unary: bool,
+        filter_layer: FilterLayer,
+        build_child_nodes: &BuildChildNodesPktFn,
+    ) {
+        let outer = Ident::new(outer_protocol.name(), Span::call_site());
+        let ident = Ident::new(protocol.name(), Span::call_site());
+        let ident_type = Ident::new(&ident.to_string().to_camel_case(), Span::call_site());
+
+        let mut body: Vec<proc_macro2::TokenStream> = vec![];
+        (build_child_nodes)(&mut body, statics, node, outer_protocol, filter_layer);
+        update_body(&mut body, node, filter_layer, false);
+
+        if first_unary {
+            code.push(quote! {
+                if let Ok(#ident) = &retina_core::protocols::packet::Packet::parse_to::<retina_core::protocols::packet::#ident::#ident_type>(#outer) {
+                    #( #body )*
+                }
+            });
+        } else {
+            code.push(quote! {
+                else if let Ok(#ident) = &retina_core::protocols::packet::Packet::parse_to::<retina_core::protocols::packet::#ident::#ident_type>(#outer) {
+                    #( #body )*
+                }
+            });
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn add_binary_pred(
+        code: &mut Vec<proc_macro2::TokenStream>,
+        statics: &mut Vec<proc_macro2::TokenStream>,
+        node: &PNode,
+        outer_protocol: &ProtocolName,
+        protocol: &ProtocolName,
+        field: &FieldName,
+        op: &BinOp,
+        value: &Value,
+        filter_layer: FilterLayer,
+        build_child_nodes: &BuildChildNodesPktFn,
+    ) {
+        let mut body: Vec<proc_macro2::TokenStream> = vec![];
+        (build_child_nodes)(&mut body, statics, node, outer_protocol, filter_layer);
+        update_body(&mut body, node, filter_layer, false);
+
+        let pred_tokenstream = binary_to_tokens(protocol, field, op, value, statics);
+        if node.if_else {
+            code.push(quote! {
+                else if #pred_tokenstream {
+                    #( #body )*
+                }
+            });
+        } else {
+            code.push(quote! {
+                if #pred_tokenstream {
+                    #( #body )*
+                }
+            });
+        }
+    }
+}
+
 // \note Because each stage's filter may be different, we default to applying an
 //       end-to-end filter at each stage. This may require, for example, re-checking
 //       IP addresses. This can/should be optimized in the future.


### PR DESCRIPTION
Especially for future compatibility with cross-layer filtering (i.e., filtering on packet fields and on protocol/session-layer data), it is ideal for the packet delivery stage to use the raw `mbuf` data for disambiguation. 