### PR TITLE
Remove PacketList Trait

### DIFF
--- a/core/src/filter/datatypes.rs
+++ b/core/src/filter/datatypes.rs
@@ -108,7 +108,7 @@ pub struct DataType {
     pub track_sessions: bool,
     /// True if the datatype requires invoking `update` method before reassembly
     pub needs_update: bool,
-    /// True if the datatype requires reassembly (for `track_packets` or `update`)
+    /// True if the datatype requires reassembly (for `update`)
     pub needs_reassembly: bool,
     /// True if the datatype requires tracking packets
     pub needs_packet_track: bool,

--- a/datatypes/src/lib.rs
+++ b/datatypes/src/lib.rs
@@ -99,17 +99,3 @@ pub trait FromSubscription {
     /// the constant value (e.g., matched filter string).
     fn from_subscription(spec: &SubscriptionSpec) -> proc_macro2::TokenStream;
 }
-
-/// Trait for a datatype that is built from a list of raw packets.
-pub trait PacketList {
-    /// Initialize internal data; called once per connection.
-    /// Note `first_pkt` will also be delivered to `update`.
-    fn new(first_pkt: &L4Pdu) -> Self;
-    /// New packet in connection received (or reassembled, if reassembled=true)
-    /// Note this may be invoked both pre- and post-reassembly; types
-    /// should check `reassembled` to avoid double-counting.
-    fn track_packet(&mut self, pdu: &L4Pdu, reassembled: bool);
-    /// Clear internal data; called if connection no longer matches filter
-    /// that requires the Tracked type.
-    fn clear(&mut self);
-}

--- a/datatypes/src/typedefs.rs
+++ b/datatypes/src/typedefs.rs
@@ -94,7 +94,7 @@ lazy_static! {
     ///
     /// For example: buffering packets may be required as a pre-match action for a
     /// packet-level datatype; it may also be required if one or more subscriptions request
-    /// a connection-level `PacketList`. Rather than maintaining these lists separately --
+    /// a connection-level `packet list`. Rather than maintaining these lists separately --
     /// one for filtering and one for delivery -- the tracked packets are stored once.
     ///
     /// Core ID is a special case, as it cannot be derived from connection,

--- a/examples/streaming/src/main.rs
+++ b/examples/streaming/src/main.rs
@@ -18,10 +18,10 @@ struct Args {
 /// following filter match (identification of TLS connection).
 /// That is, we expect the initial value of PktCount to be >3
 /// (after the TCP handshake and first data packet).
-#[filter("tls and tcp.port = 52152")]
+#[filter("tls")]
 #[streaming("packets=1")]
 fn tls_cb_pkts(pkts: &PktCount, ft: &FiveTuple) -> bool {
-    println!("{} Packet count: {}", ft, pkts.raw());
+    println!("{} Packet count: {:?}", ft, pkts);
     true
 }
 

--- a/filtergen/src/data.rs
+++ b/filtergen/src/data.rs
@@ -73,7 +73,7 @@ impl TrackedDataBuilder {
 
                 if datatype.needs_packet_track {
                     self.track_packet
-                        .push(quote! { self.#field_name.track_packet(pdu, reassembled); });
+                        .push(quote! { self.#field_name.update(pdu, reassembled); });
                     self.pkts_clear.push(quote! { self.#field_name.clear(); });
                 }
             }

--- a/filtergen/src/lib.rs
+++ b/filtergen/src/lib.rs
@@ -323,7 +323,7 @@ fn generate(input: syn::ItemFn, config: SubscriptionConfig) -> TokenStream {
         use retina_core::filter::{actions::*, datatypes::Streaming};
         // Import potentially-needed traits
         use retina_core::subscription::{Trackable, Subscribable};
-        use retina_datatypes::{FromSession, Tracked, FromMbuf, StaticData, PacketList};
+        use retina_datatypes::{FromSession, Tracked, FromMbuf, StaticData};
 
         #subscribable
 


### PR DESCRIPTION
PacketList trait was separate from Tracked trait -- both applicable to datatypes -- as an artifact of previous design. To work with streaming data, these can be the same again.